### PR TITLE
Add conversion functions from Synthesizer structure to WAV

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,52 +1,13 @@
 module Main where
 
 import Synthesizer.Encoders.Wav
+import Synthesizer.Structure
 
 import Notes.Default
 
--- 3 pulses: C5, G5, D5
--- ts = 250 ms, 250 ms
--- td = 250 ms
--- tb = 30 s
-mediumPrioritySignal :: [Sample]
-mediumPrioritySignal = cycle $ concat
-    [ note c5 250
-    , silence 250
-    , note g5 250
-    , silence 250
-    , note d5 250
-    , silence 30000
-    ]
-
--- 10 pulses: C5, A5, D5, E5, F5, C5, A5, D5, E5, F5
--- ts = 0.1 s, 0.1 s, 0.3 s, 0.1 s, 1 s, 0.1 s, 0.1 s, 0.3 s, 0.1 s, 1 s
--- td = 0.2 s
--- tb = 5 s
-highPrioritySignal :: [Sample]
-highPrioritySignal = cycle $ concat
-    [ note c5 200
-    , silence 100
-    , note a5 200
-    , silence 100
-    , note d5 200
-    , silence 300
-    , note e5 200
-    , silence 100
-    , note f5 200
-    , silence 100
-    , note c5 200
-    , silence 100
-    , note a5 200
-    , silence 100
-    , note d5 200
-    , silence 300
-    , note e5 200
-    , silence 100
-    , note f5 200
-    , silence 5000
-    ]
+mediumPrioritySignal :: SynSound
+mediumPrioritySignal = SynSound [Channel [SoundEvent 0 4 (const $ concat $ repeat [1000, 0, -1000, 0])]]
 
 main :: IO ()
 main = do
-    saveSignal "medium" $ take 5000 mediumPrioritySignal
-    saveSignal "high" $ take 5000 highPrioritySignal
+    saveSignal "medium" mediumPrioritySignal

--- a/src/Synthesizer/Structure.hs
+++ b/src/Synthesizer/Structure.hs
@@ -9,13 +9,32 @@ newtype Channel = Channel {
 }
 
 type Time         = Double
-type Length       = Int
+type Length       = Double
 type Sample       = Int
 type Frequency    = Double
 type SamplingRate = Int
 
 data SoundEvent = SoundEvent {
-  startTime :: Time,
-  length    :: Length,
-  samples   :: SamplingRate -> [Sample]
+  startTime   :: Time,
+  eventLength :: Length,
+  samples     :: SamplingRate -> [Sample]
 }
+
+-- TODO: This isn't a very efficient implementation, but it seems to be fast enough for now
+soundToSamples :: SynSound -> SamplingRate -> [Sample]
+soundToSamples sound rate = soundToSamples' sound rate 0
+
+soundToSamples' :: SynSound -> SamplingRate -> Int -> [Sample]
+soundToSamples' sound rate sampleNumber | done = []
+                                        | otherwise = sum samplesCurrentEvents : soundToSamples' sound rate (sampleNumber + 1)
+  where (currentEvents, done) = getCurrentEvents sound (fromIntegral sampleNumber / fromIntegral rate)
+        samplesCurrentEvents :: [Sample]
+        samplesCurrentEvents = map (\e -> samples e rate !! sampleNumber) currentEvents
+
+
+getCurrentEvents :: SynSound -> Time -> ([SoundEvent], Bool)
+getCurrentEvents sound time | not (null currentEvents) = (currentEvents, False)
+                            | otherwise                = (currentEvents, isDone)
+  where flatEvents = concatMap timeline (channels sound)
+        currentEvents = filter (\e -> time >= startTime e && time <= startTime e + eventLength e) flatEvents
+        isDone = not (any (\e -> time < startTime e + eventLength e) flatEvents)


### PR DESCRIPTION
Adds conversion functions from our own Synthesizer to a WAV file. Written in such a way that adding new file types should be pretty easy.

An important note is that this implementation is anything-but optimized, and is probably `O(n^2)`. We should fix this, but getting at least an MVP out is more important at the moment.