### PR TITLE
Optimize the algorithm for generating samples

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import Data.Map                 ((!))
 import Synthesizer.Encoders.Wav
 import Synthesizer.Modifiers    (amplitude, roundToSample)
 import Synthesizer.Oscillator
@@ -10,7 +11,19 @@ import Notes.Default
 mediumPrioritySignal :: SynSound
 mediumPrioritySignal = SynSound [
         Channel [
-            SoundEvent 0 1 (roundToSample . amplitude 32767 . sineOscillator 600)
+            SoundEvent 0   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "C3")),
+            SoundEvent 0.5   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "D3")),
+            SoundEvent 1   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "E3")),
+            SoundEvent 1.5   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "C3")),
+
+            SoundEvent 2   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "C3")),
+            SoundEvent 2.5   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "D3")),
+            SoundEvent 3   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "E3")),
+            SoundEvent 3.5   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "C3")),
+
+            SoundEvent 4   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "E3")),
+            SoundEvent 4.5   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "F3")),
+            SoundEvent 5   0.5 (map (round . (* 32767)) . sineOscillator (notes440 ! "G3"))
         ]
     ]
 

--- a/src/Synthesizer/Structure.hs
+++ b/src/Synthesizer/Structure.hs
@@ -52,12 +52,11 @@ soundToSamples sound rate = soundToSamples' convertedEvents [] rate 0
 
 soundToSamples' :: [SoundEventCached] -> [SoundEventCached] -> SamplingRate -> Int -> [Sample]
 soundToSamples' []      []     _    _            = []
-soundToSamples' samToDo samCur rate sampleNumber = samplesCurrentEvents : soundToSamples' updatedToDo updatedCurrent rate (sampleNumber + 1)
+soundToSamples' samToDo samCur rate sampleNumber = samplesCurrentEvents : soundToSamples' updatedToDo updatedCurrent' rate (sampleNumber + 1)
   where currentTime = fromIntegral sampleNumber / fromIntegral rate
         (updatedToDo, updatedCurrent) = mergeTodoAndCurrent (samToDo, samCur) currentTime
-        samplesCurrentEvents = foldr' (\e t -> t + samplesCached e !! (sampleNumber - sampleNumberStart (event e))) 0 updatedCurrent
-        sampleNumberStart :: SoundEvent -> Int
-        sampleNumberStart e = floor (startTime e) * rate
+        samplesCurrentEvents = foldr' (\e t -> t + head (samplesCached e)) 0 updatedCurrent
+        updatedCurrent' = map (\e -> e {samplesCached = tail (samplesCached e)}) updatedCurrent
 
 
 mergeTodoAndCurrent :: ([SoundEventCached], [SoundEventCached]) -> Time -> ([SoundEventCached], [SoundEventCached])

--- a/src/Synthesizer/Structure.hs
+++ b/src/Synthesizer/Structure.hs
@@ -1,4 +1,19 @@
-module Synthesizer.Structure where
+module Synthesizer.Structure(
+  SoundEvent(..),
+  Channel(..),
+  SynSound(..),
+  Time,
+  Length,
+  Sample,
+  Frequency,
+  PhaseLength,
+  SamplingRate,
+  soundToSamples
+) where
+
+import Data.Foldable
+import Data.List
+import Data.Ord
 
 newtype SynSound = SynSound {
   channels :: [Channel]
@@ -21,21 +36,34 @@ data SoundEvent = SoundEvent {
   samples     :: SamplingRate -> [Sample]
 }
 
--- TODO: This isn't a very efficient implementation, but it seems to be fast enough for now
+data SoundEventCached = SoundEventCached {
+  event         :: SoundEvent,
+  samplesCached :: [Sample]
+}
+
 soundToSamples :: SynSound -> SamplingRate -> [Sample]
-soundToSamples sound rate = soundToSamples' sound rate 0
+soundToSamples sound rate = soundToSamples' convertedEvents [] rate 0
+  where
+    flatEvents = concatMap timeline (channels sound)
+    sortedEvents = sortOn startTime flatEvents
+    convertedEvents = map eagerEvaluate sortedEvents
+    eagerEvaluate e = SoundEventCached e (eagerSamples e)
+    eagerSamples  e = take (rate * ceiling (eventLength e) + 1) (samples e rate)
 
-soundToSamples' :: SynSound -> SamplingRate -> Int -> [Sample]
-soundToSamples' sound rate sampleNumber | done = []
-                                        | otherwise = sum samplesCurrentEvents : soundToSamples' sound rate (sampleNumber + 1)
-  where (currentEvents, done) = getCurrentEvents sound (fromIntegral sampleNumber / fromIntegral rate)
-        samplesCurrentEvents :: [Sample]
-        samplesCurrentEvents = map (\e -> samples e rate !! sampleNumber) currentEvents
+soundToSamples' :: [SoundEventCached] -> [SoundEventCached] -> SamplingRate -> Int -> [Sample]
+soundToSamples' []      []     _    _            = []
+soundToSamples' samToDo samCur rate sampleNumber = samplesCurrentEvents : soundToSamples' updatedToDo updatedCurrent rate (sampleNumber + 1)
+  where currentTime = fromIntegral sampleNumber / fromIntegral rate
+        (updatedToDo, updatedCurrent) = mergeTodoAndCurrent (samToDo, samCur) currentTime
+        samplesCurrentEvents = foldr' (\e t -> t + samplesCached e !! (sampleNumber - sampleNumberStart (event e))) 0 updatedCurrent
+        sampleNumberStart :: SoundEvent -> Int
+        sampleNumberStart e = floor (startTime e) * rate
 
 
-getCurrentEvents :: SynSound -> Time -> ([SoundEvent], Bool)
-getCurrentEvents sound time | not (null currentEvents) = (currentEvents, False)
-                            | otherwise                = (currentEvents, isDone)
-  where flatEvents = concatMap timeline (channels sound)
-        currentEvents = filter (\e -> time >= startTime e && time <= startTime e + eventLength e) flatEvents
-        isDone = not (any (\e -> time < startTime e + eventLength e) flatEvents)
+mergeTodoAndCurrent :: ([SoundEventCached], [SoundEventCached]) -> Time -> ([SoundEventCached], [SoundEventCached])
+mergeTodoAndCurrent (todo, current) time = (newTodo, newCurrent)
+  where eventsToCurrent []     = []
+        eventsToCurrent (x:xs) = if time >= startTime (event x) then x:eventsToCurrent xs else []
+        eventsFromTodo xs      = filter (\e -> time <= startTime (event e) + eventLength (event e)) xs
+        newTodo = drop (length $ eventsToCurrent todo) todo
+        newCurrent = eventsFromTodo $ current ++ eventsToCurrent todo


### PR DESCRIPTION
This PR optimizes the algorithm for generating sound samples. Cuts down the time for the test in Main.hs by about 95%, down to around 0.6 seconds on my machine. Next step is adding some tests for this function.