### PR TITLE
Format module exports with stylish-haskell

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -20,16 +20,16 @@ steps:
   # Currently, this option is not configurable and will format all exports and
   # module declarations to minimize diffs
   #
-  # - module_header:
-  #     # How many spaces use for indentation in the module header.
-  #     indent: 4
-  #
-  #     # Should export lists be sorted?  Sorting is only performed within the
-  #     # export section, as delineated by Haddock comments.
-  #     sort: true
-  #
-  #     # See `separate_lists` for the `imports` step.
-  #     separate_lists: true
+  - module_header:
+      # How many spaces use for indentation in the module header.
+      indent: 2
+
+      # Should export lists be sorted?  Sorting is only performed within the
+      # export section, as delineated by Haddock comments.
+      sort: true
+
+      # See `separate_lists` for the `imports` step.
+      separate_lists: true
 
   # Format record definitions. This is disabled by default.
   #

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,5 @@
-module Main where
+module Main
+  where
 
 import Data.Map                        ((!))
 import Synthesizer.Encoders.Wav

--- a/src/Notes.hs
+++ b/src/Notes.hs
@@ -1,4 +1,5 @@
-module Notes where
+module Notes
+  where
 
 import Data.Map (Map, fromList, (!))
 

--- a/src/Notes/Default.hs
+++ b/src/Notes/Default.hs
@@ -1,4 +1,5 @@
-module Notes.Default where
+module Notes.Default
+  where
 
 import Data.Map (Map, (!))
 import Notes    (generateNotes)

--- a/src/Synthesizer.hs
+++ b/src/Synthesizer.hs
@@ -1,2 +1,3 @@
-module Synthesizer where
+module Synthesizer
+  where
 

--- a/src/Synthesizer/Encoders/Wav.hs
+++ b/src/Synthesizer/Encoders/Wav.hs
@@ -1,4 +1,5 @@
-module Synthesizer.Encoders.Wav where
+module Synthesizer.Encoders.Wav
+  where
 
 import qualified Codec.Audio.Wave        as W
 import           Control.Exception

--- a/src/Synthesizer/Modifiers.hs
+++ b/src/Synthesizer/Modifiers.hs
@@ -1,4 +1,5 @@
-module Synthesizer.Modifiers where
+module Synthesizer.Modifiers
+  where
 
 import Synthesizer.Structure (Sample)
 

--- a/src/Synthesizer/Modifiers/Envelopes.hs
+++ b/src/Synthesizer/Modifiers/Envelopes.hs
@@ -1,4 +1,5 @@
-module Synthesizer.Modifiers.Envelopes where
+module Synthesizer.Modifiers.Envelopes
+  where
 
 import Debug.Trace
 import Synthesizer.Structure

--- a/src/Synthesizer/Oscillator.hs
+++ b/src/Synthesizer/Oscillator.hs
@@ -1,4 +1,5 @@
-module Synthesizer.Oscillator where
+module Synthesizer.Oscillator
+  where
 
 import Data.Fixed
 import Numeric

--- a/src/Synthesizer/Structure.hs
+++ b/src/Synthesizer/Structure.hs
@@ -1,15 +1,15 @@
-module Synthesizer.Structure(
-  SoundEvent(..),
-  Channel(..),
-  SynSound(..),
-  Time,
-  Length,
-  Sample,
-  Frequency,
-  PhaseLength,
-  SamplingRate,
-  soundToSamples
-) where
+module Synthesizer.Structure
+  ( Channel (..)
+  , Frequency
+  , Length
+  , PhaseLength
+  , Sample
+  , SamplingRate
+  , SoundEvent (..)
+  , SynSound (..)
+  , Time
+  , soundToSamples
+  ) where
 
 import Data.Foldable
 import Data.List


### PR DESCRIPTION
Use `stylish-haskell` to format modules, since otherwise it might become a mess.