### PR TITLE
Add unit tests using `tasty`

### DIFF
--- a/haskell-synthesizer.cabal
+++ b/haskell-synthesizer.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 394311272731bd20a4ff87749af0c9287f87381601a9f06c9e74461831ba32ed
+-- hash: 0f4e51a29635d741d86986a17a0adc8a8eecf574018e51f4d771cf0895080562
 
 name:           haskell-synthesizer
 version:        0.1.0.0
@@ -65,11 +65,12 @@ executable haskell-synthesizer-exe
 
 test-suite haskell-synthesizer-test
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: test.hs
   other-modules:
+      Tests.Notes
       Paths_haskell_synthesizer
   hs-source-dirs:
-      test
+      tests
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
@@ -77,5 +78,7 @@ test-suite haskell-synthesizer-test
     , containers
     , directory
     , haskell-synthesizer
+    , tasty
+    , tasty-hunit
     , wave
   default-language: Haskell2010

--- a/haskell-synthesizer.cabal
+++ b/haskell-synthesizer.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0f4e51a29635d741d86986a17a0adc8a8eecf574018e51f4d771cf0895080562
+-- hash: 774404d7b023e03cf038bc7e68dd65e6ffc0450aa9564bb85b2ff64b61095c68
 
 name:           haskell-synthesizer
 version:        0.1.0.0
@@ -68,6 +68,9 @@ test-suite haskell-synthesizer-test
   main-is: test.hs
   other-modules:
       Tests.Notes
+      Tests.Notes.Default
+      Tests.Synthesizer.Oscillator
+      Tests.Synthesizer.Structure
       Paths_haskell_synthesizer
   hs-source-dirs:
       tests

--- a/package.yaml
+++ b/package.yaml
@@ -42,11 +42,13 @@ executables:
 
 tests:
   haskell-synthesizer-test:
-    main:                Spec.hs
-    source-dirs:         test
+    main:                test.hs
+    source-dirs:         tests
     ghc-options:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
     - haskell-synthesizer
+    - tasty
+    - tasty-hunit

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,0 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"

--- a/tests/Tests/Notes.hs
+++ b/tests/Tests/Notes.hs
@@ -1,0 +1,24 @@
+module Tests.Notes where
+
+import Test.Tasty.HUnit
+import Notes
+import Data.Map ((!))
+
+notesTests =
+  [ testNumberOfScaleNotes
+  , test12Notes
+  , testB5Note
+  , testGenerateNote
+  , testFrequencyStep
+  , testNumberOfSemitones
+  , testFrequencyToWaveLength
+  , testWaveLengthToFrequency ]
+
+testNumberOfScaleNotes    = testCase "the number of scale notes is 9 times the length of notes" $ numberOfScaleNotes @?= 108
+test12Notes               = testCase "there are 12 notes" $ length notes @?= 12
+testB5Note                = testCase "the frequency of the B5 note is correct" $ generateNotes 440 ! "B5" @?= 987.7666025122364
+testGenerateNote          = testCase "the generation of a D note is correct" $ generateNote 440 2 @?= ("D0", 493.88330125612396)
+testFrequencyStep         = testCase "the correct frequency step is taken" $ frequencySteps 440 2 @?= 493.88330125612396
+testNumberOfSemitones     = testCase "the correct number of semitones is generated" $ numberOfSemitones 440 500 @?= 2
+testFrequencyToWaveLength = testCase "the correct frequency wavelength conversion is done" $ frequencyToWaveLength 440 @?= 0.7840909090909091
+testWaveLengthToFrequency = testCase "the correct wavelength to frequency conversion is done" $ wavelengthToFrequency 0.5 @?= 690.0

--- a/tests/Tests/Notes/Default.hs
+++ b/tests/Tests/Notes/Default.hs
@@ -1,0 +1,21 @@
+module Tests.Notes.Default where
+
+import Test.Tasty.HUnit
+import Notes.Default
+
+defaultNotesTests =
+  [ testA5Freq
+  , testB5Freq
+  , testC5Freq
+  , testD5Freq
+  , testE5Freq
+  , testF5Freq
+  , testG5Freq ]
+
+testA5Freq = testCase "The correct frequency for a A5 note is generated" $ a5 @?= 879.9999999999899
+testB5Freq = testCase "The correct frequency for a B5 note is generated" $ b5 @?= 987.7666025122364
+testC5Freq = testCase "The correct frequency for a C5 note is generated" $ c5 @?= 523.2511306011921
+testD5Freq = testCase "The correct frequency for a D5 note is generated" $ d5 @?= 587.3295358348091
+testE5Freq = testCase "The correct frequency for a E5 note is generated" $ e5 @?= 659.2551138257329
+testF5Freq = testCase "The correct frequency for a F5 note is generated" $ f5 @?= 698.4564628660003
+testG5Freq = testCase "The correct frequency for a G5 note is generated" $ g5 @?= 783.9908719634899

--- a/tests/Tests/Synthesizer/Oscillator.hs
+++ b/tests/Tests/Synthesizer/Oscillator.hs
@@ -1,0 +1,14 @@
+module Tests.Synthesizer.Oscillator where
+
+import Test.Tasty.HUnit
+import Synthesizer.Oscillator
+
+oscillatorStructureTests =
+  [ testSawToothOscillator
+  , testSineOscillator ]
+
+testSawToothOscillator = testCase "The correct samples of a saw tooth osciallator are generated"
+  $ map round (take 10 (sawToothOscillator 400 10)) @?= [0, 251, 103, 354, 205, 57, 308, 159, 11, 262]
+
+testSineOscillator = testCase "Test correct samples of a sine oscillator are generated"
+  $ map (\e -> round (e * 10**3)) (take 10 (sineOscillator 2 10)) @?= [0, 951, 588, -588, -951, 0, 951, 588, -588, -951]

--- a/tests/Tests/Synthesizer/Structure.hs
+++ b/tests/Tests/Synthesizer/Structure.hs
@@ -1,0 +1,38 @@
+module Tests.Synthesizer.Structure where
+
+import Test.Tasty.HUnit
+import Synthesizer.Structure
+
+synthesizerStructureTests =
+  [ testSampleGenerationSimple
+  , testSampleMultipleEvents
+  , testSampleMultipleChannels
+  , testSampleGenerationTimeSteps ]
+
+-- TODO: Seems like the sampling algorithm goes one too far, we should need a `replicate` 20
+testSampleGenerationSimple = testCase "a simple waveform is sampled correctly" $ soundToSamples structure 10 @?= replicate 21 100 ++ [0]
+  where structure = SynSound channels
+        channels = [Channel timeline]
+        timeline = [ SoundEvent 0 2 (const [100, 100..]) ]
+
+-- TODO: Seems like the sampling algorithm goes one too far, we should need a `replicate` 10
+testSampleMultipleEvents = testCase "a simple waveform with multiple events is sampled correctly"
+  $ soundToSamples structure 10 @?= replicate 10 100 ++ replicate 11 200 ++ [0]
+  where structure = SynSound channels
+        channels = [Channel timeline]
+        timeline = [SoundEvent 0 2 (const [100, 100..]), SoundEvent 1 1 (const [100, 100..])]
+
+-- TODO: Seems like the sampling algorithm goes one too far, we should need a `replicate` 10
+testSampleMultipleChannels = testCase "a simple waveform with multiple channels is sampled correctly"
+  $ soundToSamples structure 10 @?= replicate 10 100 ++ replicate 11 200 ++ [0]
+  where structure = SynSound channels
+        channels = [Channel timeline1, Channel timeline2]
+        timeline1 = [SoundEvent 0 2 (const [100, 100..])]
+        timeline2 = [SoundEvent 1 1 (const [100, 100..])]
+
+-- TODO: Seems like the sampling algorithm goes one too far, we should need a `replicate` 10
+testSampleGenerationTimeSteps = testCase "a simple testcase with blank periods"
+  $ soundToSamples structure 10 @?= [10..20] ++ replicate 9 0 ++ [20..30] ++ [0]
+  where structure = SynSound channels
+        channels = [Channel timeline]
+        timeline = [SoundEvent 0 1 (const [10..20]), SoundEvent 2 1 (const [20..30])]

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,5 +1,8 @@
 import Test.Tasty
 import Tests.Notes
+import Tests.Notes.Default
+import Tests.Synthesizer.Structure
+import Tests.Synthesizer.Oscillator
 
 main = defaultMain tests
 
@@ -7,6 +10,8 @@ tests :: TestTree
 tests = testGroup "Tests" [unitTestsTree]
 
 unitTestsTree :: TestTree
-unitTestsTree = testGroup "UnitTests" [unitTests]
-
-unitTests = testGroup "(HUnit)" notesTests
+unitTestsTree = testGroup "UnitTests"
+  [ testGroup "Tests.Notes" notesTests
+  , testGroup "Tests.Notes.Default" defaultNotesTests
+  , testGroup "Tests.Synthesizer.Structure" synthesizerStructureTests
+  , testGroup "Tests.Synthesizer.Oscillator" oscillatorStructureTests ]

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,0 +1,12 @@
+import Test.Tasty
+import Tests.Notes
+
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Tests" [unitTestsTree]
+
+unitTestsTree :: TestTree
+unitTestsTree = testGroup "UnitTests" [unitTests]
+
+unitTests = testGroup "(HUnit)" notesTests


### PR DESCRIPTION
Adds the unit testing framework and the first few unit tests using the `tasty` framework. Adding unit tests should be as simple as adding the correct reference to `test.hs`.