### PR TITLE
Fix bug that generated a sample to much

### DIFF
--- a/src/Synthesizer/Structure.hs
+++ b/src/Synthesizer/Structure.hs
@@ -65,6 +65,6 @@ mergeTodoAndCurrent :: ([SoundEventCached], [SoundEventCached]) -> Time -> ([Sou
 mergeTodoAndCurrent (todo, current) time = (newTodo, newCurrent)
   where eventsToCurrent []     = []
         eventsToCurrent (x:xs) = if time >= startTime (event x) then x:eventsToCurrent xs else []
-        eventsFromTodo xs      = filter (\e -> time <= startTime (event e) + eventLength (event e)) xs
+        eventsFromTodo xs      = filter (\e -> time < startTime (event e) + eventLength (event e)) xs
         newTodo = drop (length $ eventsToCurrent todo) todo
         newCurrent = eventsFromTodo $ current ++ eventsToCurrent todo

--- a/tests/Tests/Synthesizer/Structure.hs
+++ b/tests/Tests/Synthesizer/Structure.hs
@@ -9,30 +9,26 @@ synthesizerStructureTests =
   , testSampleMultipleChannels
   , testSampleGenerationTimeSteps ]
 
--- TODO: Seems like the sampling algorithm goes one too far, we should need a `replicate` 20
-testSampleGenerationSimple = testCase "a simple waveform is sampled correctly" $ soundToSamples structure 10 @?= replicate 21 100 ++ [0]
+testSampleGenerationSimple = testCase "a simple waveform is sampled correctly" $ soundToSamples structure 10 @?= replicate 20 100 ++ [0]
   where structure = SynSound channels
         channels = [Channel timeline]
         timeline = [ SoundEvent 0 2 (const [100, 100..]) ]
 
--- TODO: Seems like the sampling algorithm goes one too far, we should need a `replicate` 10
 testSampleMultipleEvents = testCase "a simple waveform with multiple events is sampled correctly"
-  $ soundToSamples structure 10 @?= replicate 10 100 ++ replicate 11 200 ++ [0]
+  $ soundToSamples structure 10 @?= replicate 10 100 ++ replicate 10 200 ++ [0]
   where structure = SynSound channels
         channels = [Channel timeline]
         timeline = [SoundEvent 0 2 (const [100, 100..]), SoundEvent 1 1 (const [100, 100..])]
 
--- TODO: Seems like the sampling algorithm goes one too far, we should need a `replicate` 10
 testSampleMultipleChannels = testCase "a simple waveform with multiple channels is sampled correctly"
-  $ soundToSamples structure 10 @?= replicate 10 100 ++ replicate 11 200 ++ [0]
+  $ soundToSamples structure 10 @?= replicate 10 100 ++ replicate 10 200 ++ [0]
   where structure = SynSound channels
         channels = [Channel timeline1, Channel timeline2]
         timeline1 = [SoundEvent 0 2 (const [100, 100..])]
         timeline2 = [SoundEvent 1 1 (const [100, 100..])]
 
--- TODO: Seems like the sampling algorithm goes one too far, we should need a `replicate` 10
 testSampleGenerationTimeSteps = testCase "a simple testcase with blank periods"
-  $ soundToSamples structure 10 @?= [10..20] ++ replicate 9 0 ++ [20..30] ++ [0]
+  $ soundToSamples structure 10 @?= [10..19] ++ replicate 10 0 ++ [20..29] ++ [0]
   where structure = SynSound channels
         channels = [Channel timeline]
         timeline = [SoundEvent 0 1 (const [10..20]), SoundEvent 2 1 (const [20..30])]


### PR DESCRIPTION
There was a bug in the sampling algorithm that made a sample too much. For example, if the length of an event was 1, with a sampling rate of 10, 11 samples were generated instead of 10. With this fix 10 samples are generated.