### PR TITLE
Add helper functions with tests for interaction with the synthesizer

### DIFF
--- a/src/Synthesizer/Structure.hs
+++ b/src/Synthesizer/Structure.hs
@@ -21,11 +21,11 @@ import Data.Ord
 
 newtype SynSound = SynSound {
   channels :: [Channel]
-} deriving (Show)
+} deriving (Show, Eq)
 
 newtype Channel = Channel {
   timeline :: [SoundEvent]
-} deriving (Show)
+} deriving (Show, Eq)
 
 type Time         = Double
 type Length       = Double
@@ -39,6 +39,13 @@ data SoundEvent = SoundEvent {
   eventLength :: Length,
   samples     :: SamplingRate -> [Sample]
 }
+
+-- | Eq instance for SoundEvents. It should be noted that this isn't 100% sound, as if the first 100 samples are exactly
+-- | the same but a sample after that is different, this will be unsound.
+instance Eq SoundEvent where
+  a == b = startTime a == startTime b &&
+           eventLength a == eventLength b &&
+           take 100 (samples a 100) == take 100 (samples b 100)
 
 instance Show SoundEvent where
   show (SoundEvent startTime eventLength _) = "SoundEvent { startTime = " ++ show startTime ++ " eventLength = " ++ show eventLength ++ " samples = ... }"

--- a/tests/Tests/Synthesizer/Structure.hs
+++ b/tests/Tests/Synthesizer/Structure.hs
@@ -7,7 +7,10 @@ synthesizerStructureTests =
   [ testSampleGenerationSimple
   , testSampleMultipleEvents
   , testSampleMultipleChannels
-  , testSampleGenerationTimeSteps ]
+  , testSampleGenerationTimeSteps
+  , testGetAllEvents
+  , testAddChannel
+  , testAddToNewChannel ]
 
 testSampleGenerationSimple = testCase "a simple waveform is sampled correctly" $ soundToSamples structure 10 @?= replicate 20 100 ++ [0]
   where structure = SynSound channels
@@ -32,3 +35,27 @@ testSampleGenerationTimeSteps = testCase "a simple testcase with blank periods"
   where structure = SynSound channels
         channels = [Channel timeline]
         timeline = [SoundEvent 0 1 (const [10..20]), SoundEvent 2 1 (const [20..30])]
+
+testGetAllEvents = testCase "check if we get all events"
+  $ getAllEvents structure @?= events
+  where events = [SoundEvent 0 1 (const [10..20]), SoundEvent 2 1 (const [20..30]), SoundEvent 3 1 (const [30..40])]
+        channels = [Channel (take 2 events), Channel [events !! 2]]
+        structure = SynSound channels
+
+testGetAllEventsDuring = testCase "check if we get all events during a specific period"
+  $ getAllEventsDuring structure (2, 4) @?= eventsDuring
+  where eventsDuring = [SoundEvent 1 2 (const [1..]), SoundEvent 2 2 (const [1..]), SoundEvent 3 2 (const [1..])]
+        eventsNotDuring = [SoundEvent 0 2 (const [1..]), SoundEvent 4 1 (const [1..])]
+        events = eventsDuring ++ eventsNotDuring
+        channels = [Channel events]
+        structure = SynSound channels
+
+testAddChannel = testCase "check if we can add a channel"
+  $ channels (addChannel structure channel) @?= [channel]
+  where structure = SynSound []
+        channel = Channel [SoundEvent 0 1 (const [10..20])]
+
+testAddToNewChannel = testCase "check if we can add a new channel with events"
+  $ channels (addToNewChannel structure events) @?= [Channel events]
+  where structure = SynSound []
+        events = [SoundEvent 0 1 (const [10..20])]

--- a/tests/Tests/Synthesizer/Structure.hs
+++ b/tests/Tests/Synthesizer/Structure.hs
@@ -9,6 +9,7 @@ synthesizerStructureTests =
   , testSampleMultipleChannels
   , testSampleGenerationTimeSteps
   , testGetAllEvents
+  , testGetAllEventsDuring
   , testAddChannel
   , testAddToNewChannel ]
 


### PR DESCRIPTION
Adds the `addChannel`, `addToNewChannel`, `getAllEvents` and `getAllEventsDuring` functions. Also provides an (somewhat unsound) `Eq` implementation for SynSounds.